### PR TITLE
Update 'exports/context.tf' version pinning

### DIFF
--- a/exports/context.tf
+++ b/exports/context.tf
@@ -20,7 +20,7 @@
 
 module "this" {
   source  = "cloudposse/label/null"
-  version = "0.18.0" // requires Terraform >= 0.12.26
+  version = "0.19.0" // requires Terraform >= 0.12.26
   enabled             = var.enabled
   namespace           = var.namespace
   environment         = var.environment


### PR DESCRIPTION
## what
This is an auto-generated PR that updates 'exports/context.tf' with most recent release of this repo.

## why
As 'exports/context.tf' is used by foreign modules it should be pinned to most recent release of this repo.